### PR TITLE
Fix sema inside function

### DIFF
--- a/include/clang/Parse/Parser.h
+++ b/include/clang/Parse/Parser.h
@@ -1954,6 +1954,10 @@ private:
     bool ParsedForRangeDecl() { return !ColonLoc.isInvalid(); }
   };
 
+  DeclGroupPtrTy SplittableParseDeclaration(DeclaratorContext Context,
+                                            SourceLocation &DeclEnd,
+                                            ParsedAttributesWithRange &attrs);
+
   DeclGroupPtrTy ParseDeclaration(DeclaratorContext Context,
                                   SourceLocation &DeclEnd,
                                   ParsedAttributesWithRange &attrs);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1653,7 +1653,7 @@ void Parser::stripTypeAttributesOffDeclSpec(ParsedAttributesWithRange &Attrs,
 /// [C++11/C11] static_assert-declaration
 ///         others... [FIXME]
 ///
-Parser::DeclGroupPtrTy Parser::ParseDeclaration(DeclaratorContext Context,
+Parser::DeclGroupPtrTy Parser::SplittableParseDeclaration(DeclaratorContext Context,
                                                 SourceLocation &DeclEnd,
                                           ParsedAttributesWithRange &attrs) {
   ParenBraceBracketBalancer BalancerRAIIObj(*this);
@@ -1695,6 +1695,24 @@ Parser::DeclGroupPtrTy Parser::ParseDeclaration(DeclaratorContext Context,
   // This routine returns a DeclGroup, if the thing we parsed only contains a
   // single decl, convert it now.
   return Actions.ConvertDeclToDeclGroup(SingleDecl);
+}
+
+Parser::DeclGroupPtrTy Parser::ParseDeclaration(DeclaratorContext Context,
+                                        SourceLocation &DeclEnd,
+                                        ParsedAttributesWithRange &attrs) {
+  DeclGroupPtrTy Result = SplittableParseDeclaration(Context, DeclEnd, attrs);
+
+  // Attach presence condition to the declaration so that it can be taken into
+  // account during lookup
+  if (Result.get().isNull()) {
+  } else if (Result.get().isSingleDecl()) {
+    Result.get().getSingleDecl()->setConditional(this->getConditional());
+  } else {
+    for(unsigned int i = 0; i < Result.get().getDeclGroup().size(); i++){
+      Result.get().getDeclGroup()[i]->setConditional(this->getConditional());
+    }
+  }
+  return Result;
 }
 
 ///       simple-declaration: [C99 6.7: declaration] [C++ 7p1: dcl.dcl]

--- a/lib/Sema/SemaLookup.cpp
+++ b/lib/Sema/SemaLookup.cpp
@@ -1759,6 +1759,11 @@ void LookupResult::TryAndResolveContextualAmbiguity(){
         //addDecl(d);
         addDecl(one); // Temporary, return first value
     }
+  } else {
+    // Ensure that if there is only one Decl, ResultKind is not Ambiguous
+    if (ResultKind == Ambiguous && Decls.size() == 1) {
+      ResultKind = Found;
+    }
   }
 
 }


### PR DESCRIPTION
This merge makes the parser update the presence condition of the scope correctly while inside ParseStatementOrDeclaration