### PR TITLE
Fix splitting on adjacent ifdefs

### DIFF
--- a/include/clang/Basic/Conditional.h
+++ b/include/clang/Basic/Conditional.h
@@ -52,6 +52,10 @@ public:
     bool ShouldContinueOnCondition(PresenceCondition* other);
     bool ShouldSkipOnCondition(PresenceCondition* other);
     bool ShouldJoinOnCondition(PresenceCondition* other);
+    // Returns true if this is logically equivalent to other
+    bool EquivalentTo(PresenceCondition* other);
+    // Returns true if this implies other is a tautology
+    bool Implies(PresenceCondition* other);
     void solve(PresenceCondition* other);
 
     virtual ~PresenceCondition() {}

--- a/lib/Basic/Conditional.cpp
+++ b/lib/Basic/Conditional.cpp
@@ -35,6 +35,14 @@ bool PresenceCondition::ShouldSkipOnCondition(PresenceCondition* other) {
     return !this->solve_map[other->toString()][0] && this->solve_map[other->toString()][1];
 }
 
+bool PresenceCondition::EquivalentTo(PresenceCondition* other) {
+  return this->Implies(other) && other->Implies(this);
+}
+
+bool PresenceCondition::Implies(PresenceCondition* other) {
+  PresenceCondition *equ = new And(this, new Not(other));
+  return !equ->isSatisfiable();
+}
 
 void PresenceCondition::solve(PresenceCondition* other){
     if(toString() == other->toString()){

--- a/lib/Basic/Conditional.cpp
+++ b/lib/Basic/Conditional.cpp
@@ -19,7 +19,8 @@ bool PresenceCondition::ShouldJoinOnCondition(PresenceCondition* other) {
     if(this->solve_map.find(other->toString()) == this->solve_map.end()){
         this->solve(other);
     }
-    return this->solve_map[other->toString()][2] && !this->solve_map[other->toString()][3];
+    //return this->solve_map[other->toString()][2] && !this->solve_map[other->toString()][3];
+    return (new Variability::And(new Variability::Not(this), other))->isSatisfiable();
 }
 bool PresenceCondition::ShouldContinueOnCondition(PresenceCondition* other) {
     if(this->solve_map.find(other->toString()) == this->solve_map.end()){

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -182,7 +182,15 @@ StmtResult Parser::ParseVariantBody(StmtVector &PrevStmts,
 
 
   if(Tok.is(tok::split)) {
-    ConsumeToken();
+    if (this->getConditional()->ShouldJoinOnCondition(Tok.getConditional())) {
+      // This handles the case where there are 2 adjacent ifdefs next to each
+      // other. In this case, the parser will encounter a split token, but
+      // instead of splitting, it should join. This avoid the recursive call to
+      // ParseStatementOrDeclaration
+      goto done;
+    } else {
+      ConsumeToken();
+    }
   }
 
   //llvm::outs() << getConditional()->ShouldJoinOnCondition(Tok.getConditional())
@@ -201,6 +209,7 @@ StmtResult Parser::ParseVariantBody(StmtVector &PrevStmts,
 
   }
 
+done:
   SourceLocation CloseLoc = Tok.getLocation();
   return Actions.ActOnCompoundStmt(StartLoc, CloseLoc,
                                    Stmts, false);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -187,7 +187,7 @@ StmtResult Parser::ParseVariantBody(StmtVector &PrevStmts,
       // other. In this case, the parser will encounter a split token, but
       // instead of splitting, it should join. This avoid the recursive call to
       // ParseStatementOrDeclaration
-      goto done;
+      goto Join;
     } else {
       ConsumeToken();
     }
@@ -209,7 +209,7 @@ StmtResult Parser::ParseVariantBody(StmtVector &PrevStmts,
 
   }
 
-done:
+Join:
   SourceLocation CloseLoc = Tok.getLocation();
   return Actions.ActOnCompoundStmt(StartLoc, CloseLoc,
                                    Stmts, false);


### PR DESCRIPTION
This fixes issue #8 where the parser was treating adjacent ifdefs as if they were nested. Now, instead of always splitting at a split token, the parser checks if it should join first.