### PR TITLE
Fix #18 (Nesting in else clauses is sometimes parsed incorrectly)

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -200,7 +200,8 @@ StmtResult Parser::ParseVariantBody(StmtVector &PrevStmts,
       // instead of splitting, it should join. This avoid the recursive call to
       // ParseStatementOrDeclaration
       goto Join;
-    } else {
+    } else if (!this->getConditional()->ShouldSplitOnCondition(Tok.getConditional())) {
+      // Consume the split token if we don't need to split on it
       ConsumeToken();
     }
   }


### PR DESCRIPTION
In Parser::ParseVariantBody, when a split token is encountered at the beginning of a varint body, check if should split instead of just skipping.