### PR TITLE
Fix bug with special characters in macro names

### DIFF
--- a/lib/Basic/Conditional.cpp
+++ b/lib/Basic/Conditional.cpp
@@ -120,9 +120,16 @@ bool PresenceCondition::isSatisfiable() {
             clause.clear();
         }else if(cnf[i] == '~'){
             isNeg = !isNeg;
-        }else if(isalpha(cnf[i])){
+        }else{
+            // Accept any characters other than '(', ')', ' ', '|', or '&'
+            // as part of a macro name
             std::string name = "";
-            while(isalpha(cnf[i])){
+            while(cnf[i] != '(' &&
+                  cnf[i] != ')' &&
+                  cnf[i] != ' ' &&
+                  cnf[i] != '|' &&
+                  cnf[i] != '&' &&
+                  cnf[i] != '\0'){
                 name += cnf[i++];
             }
             if(map.find(name) == map.end()){


### PR DESCRIPTION
Adjust PresenceCondition::isSatisfiable method to accept any characters (not just alpha) in macro names.

Fixes #21 