### PR TITLE
Fix incorrect parsing of if stmts inside ifdefs.

### DIFF
--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -927,6 +927,9 @@ void Preprocessor::HandleDirective(Token &Result) {
   // and reset to previous state when returning from this function.
   ResetMacroExpansionHelper helper(this);
 
+  // Manage VariabiltyStack (push/pop) if necessary
+  ManageMyStack(Result);
+
   switch (Result.getKind()) {
   case tok::eod:
     return;   // null directive.

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -793,7 +793,6 @@ void Preprocessor::Lex(Token &Result) {
       AssignConditional(Result);
       break;
     }
-    ManageMyStack(Result);
   } while (!ReturnedToken);
 
   if (Result.is(tok::code_completion))


### PR DESCRIPTION
Call Preprocessor::ManageMyStack inside HandleDirective instead of Lex. Fixes #24.