### PR TITLE
Pop from VariabilityStack when an if or ifdef block is skipped

### DIFF
--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2738,12 +2738,16 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
         CurPPLexer->pushConditionalLevel(DirectiveTok.getLocation(),
                                          /*wasskip*/false, /*foundnonskip*/true,
                                          /*foundelse*/false);
-    else
+    else {
+        // Normally, we would pop from VariabilityStack when an #endif token is
+        // encountered. However, since the #endif will be skipped, we must pop here.
+        VariabilityStack.pop_back();
         // No, skip the contents of this block.
         SkipExcludedConditionalBlock(HashToken.getLocation(),
                                      DirectiveTok.getLocation(),
                                      /*Foundnonskip*/ false,
                                      /*FoundElse*/ false);
+    }
   }
 }
 
@@ -2787,6 +2791,9 @@ void Preprocessor::HandleIfDirective(Token &IfToken,
     CurPPLexer->pushConditionalLevel(IfToken.getLocation(), /*wasskip*/false,
                                    /*foundnonskip*/true, /*foundelse*/false);
   } else {
+    // Normally, we would pop from VariabilityStack when an #endif token is
+    // encountered. However, since the #endif will be skipped, we must pop here.
+    VariabilityStack.pop_back();
     // No, skip the contents of this block.
     SkipExcludedConditionalBlock(HashToken.getLocation(), IfToken.getLocation(),
                                  /*Foundnonskip*/ false,


### PR DESCRIPTION
This ensures that Preprocessor::VariabilityStack stays balanced

Fixes #36