### PR TITLE
Only push to VariabilityStack when an ifdef or if will be used for variability-aware analysis

### DIFF
--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -138,6 +138,19 @@ class Preprocessor {
   std::unordered_set<std::string> VariabilityMacros;
   std::vector<VariabilityLocation> VariabilityStack;
 
+  // Define hash function for SourceLocation so that it can be used in a
+  // std::unordered_set
+  class SourceLocationHash {
+  public:
+    size_t operator()(const SourceLocation &loc) const {
+      return (size_t)loc.getRawEncoding();
+    }
+  };
+  // A set to store SourceLocations of #if or #ifdef's that have been used for
+  // variability-aware analysis. This helps decided whether or not we need to
+  // pop from VariabilityStack when an #endif is encountered
+  std::unordered_set<SourceLocation, SourceLocationHash> VariabilityIfLocations;
+
   std::shared_ptr<PreprocessorOptions> PPOpts;
   DiagnosticsEngine        *Diags;
   LangOptions       &LangOpts;

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -1268,8 +1268,6 @@ public:
   /// \brief Lex the next token for this preprocessor.
   void Lex(Token &Result);
 
-  void ManageMyStack(Token &Result);
-
   void AssignConditional(Token &Result);
 
   void LexAfterModuleImport(Token &Result);

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2820,7 +2820,6 @@ void Preprocessor::HandleEndifDirective(Token &EndifToken) {
 
   // If this #endif corresponds to an #if or #ifdef used in variability-aware analysis,
   // we must pop an item from VariabilityStack
-  //if (VariabilityIfLocations.find(CondInfo.IfLoc) != VariabilityIfLocations.end())
   if (isVariabilityIfLoc(CondInfo.IfLoc))
     VariabilityStack.pop_back();
 
@@ -2865,7 +2864,6 @@ void Preprocessor::HandleElseDirective(Token &Result, const Token &HashToken) {
 
   // Only skip the rest of this block if we are not performing variability-aware
   // analysis on it
-  //if (VariabilityIfLocations.find(CI.IfLoc) == VariabilityIfLocations.end()) {
   if (!isVariabilityIfLoc(CI.IfLoc)) {
     // Finally, skip the rest of the contents of this block.
     SkipExcludedConditionalBlock(HashToken.getLocation(), CI.IfLoc,
@@ -2922,7 +2920,6 @@ void Preprocessor::HandleElifDirective(Token &ElifToken,
 
   // For now, if we are performing variability-aware analysis on a block but
   // an #elif is encountered, just skip it
-  //if (VariabilityIfLocations.find(CI.IfLoc) != VariabilityIfLocations.end())
   if (isVariabilityIfLoc(CI.IfLoc))
     VariabilityStack.pop_back();
 

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2738,16 +2738,12 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
         CurPPLexer->pushConditionalLevel(DirectiveTok.getLocation(),
                                          /*wasskip*/false, /*foundnonskip*/true,
                                          /*foundelse*/false);
-    else {
-        // Normally, we would pop from VariabilityStack when an #endif token is
-        // encountered. However, since the #endif will be skipped, we must pop here.
-        VariabilityStack.pop_back();
+    else
         // No, skip the contents of this block.
         SkipExcludedConditionalBlock(HashToken.getLocation(),
                                      DirectiveTok.getLocation(),
                                      /*Foundnonskip*/ false,
                                      /*FoundElse*/ false);
-    }
   }
 }
 
@@ -2791,9 +2787,6 @@ void Preprocessor::HandleIfDirective(Token &IfToken,
     CurPPLexer->pushConditionalLevel(IfToken.getLocation(), /*wasskip*/false,
                                    /*foundnonskip*/true, /*foundelse*/false);
   } else {
-    // Normally, we would pop from VariabilityStack when an #endif token is
-    // encountered. However, since the #endif will be skipped, we must pop here.
-    VariabilityStack.pop_back();
     // No, skip the contents of this block.
     SkipExcludedConditionalBlock(HashToken.getLocation(), IfToken.getLocation(),
                                  /*Foundnonskip*/ false,

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2731,11 +2731,10 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
                                      /*wasskip*/false, /*foundnonskip*/true,
                                      /*foundelse*/false);
     std::string name = getSpelling(MacroNameTok);
-    VariabilityIfLocations.insert(DirectiveTok.getLocation());
     if (isIfndef)
-      VariabilityStack.push_back({false, true, name});
+      VariabilityStack.push_back({false, DirectiveTok.getLocation(), name});
     else
-      VariabilityStack.push_back({true, true, name});
+      VariabilityStack.push_back({true, DirectiveTok.getLocation(), name});
   } else if (!MI == isIfndef) {
     // Yes, remember that we are inside a conditional, then lex the next token.
     CurPPLexer->pushConditionalLevel(DirectiveTok.getLocation(),
@@ -2821,7 +2820,8 @@ void Preprocessor::HandleEndifDirective(Token &EndifToken) {
 
   // If this #endif corresponds to an #if or #ifdef used in variability-aware analysis,
   // we must pop an item from VariabilityStack
-  if (VariabilityIfLocations.find(CondInfo.IfLoc) != VariabilityIfLocations.end())
+  //if (VariabilityIfLocations.find(CondInfo.IfLoc) != VariabilityIfLocations.end())
+  if (isVariabilityIfLoc(CondInfo.IfLoc))
     VariabilityStack.pop_back();
 
   if (Callbacks)
@@ -2865,7 +2865,8 @@ void Preprocessor::HandleElseDirective(Token &Result, const Token &HashToken) {
 
   // Only skip the rest of this block if we are not performing variability-aware
   // analysis on it
-  if (VariabilityIfLocations.find(CI.IfLoc) == VariabilityIfLocations.end()) {
+  //if (VariabilityIfLocations.find(CI.IfLoc) == VariabilityIfLocations.end()) {
+  if (!isVariabilityIfLoc(CI.IfLoc)) {
     // Finally, skip the rest of the contents of this block.
     SkipExcludedConditionalBlock(HashToken.getLocation(), CI.IfLoc,
                                  /*Foundnonskip*/ true,
@@ -2921,7 +2922,8 @@ void Preprocessor::HandleElifDirective(Token &ElifToken,
 
   // For now, if we are performing variability-aware analysis on a block but
   // an #elif is encountered, just skip it
-  if (VariabilityIfLocations.find(CI.IfLoc) != VariabilityIfLocations.end())
+  //if (VariabilityIfLocations.find(CI.IfLoc) != VariabilityIfLocations.end())
+  if (isVariabilityIfLoc(CI.IfLoc))
     VariabilityStack.pop_back();
 
   // Finally, skip the rest of the contents of this block.

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -801,50 +801,6 @@ void Preprocessor::Lex(Token &Result) {
   LastTokenWasAt = Result.is(tok::at);
   //llvm::outs() << Result.getConditional()->toString() << "\n";
 }
-int death_count = 0;
-void Preprocessor::ManageMyStack(Token &Result){
-  static bool wasEndOfDirective = false;
-  //llvm::outs() << "DC:" << death_count++ << "\n";
-  if(!Result.is(tok::raw_identifier) && !Result.isAnnotation() && !Result.is(tok::split)){
-#define createName \
-    Token t;\
-    getRawToken(Result.getEndLoc().getLocWithOffset(1), t, true);\
-    std::string name = getSpelling(t);
-
-      //llvm::outs() << "Attempted   " << Result.getName() << ":" << getSpelling(Result)
-        //<< "   Flags: " << Result.getFlags()
-        //<< "\n";
-
-
-  IdentifierInfo *II = Result.getIdentifierInfo();
-    if (II && (!wasEndOfDirective || getSpelling(Result) == "ifdef" || getSpelling(Result) == "ifndef") && II->getPPKeywordID()){
-      //llvm::outs() << "Allowed   " << Result.getName() << ":" << getSpelling(Result)
-        //<< "   Flags: " << Result.getFlags()
-        //<< "   PPID: " << II->getPPKeywordID()
-        //<< "\n";
-      if(II->getPPKeywordID() == tok::pp_ifdef){
-        createName
-        if (isMacroVariability(name)) {
-          VariabilityIfLocations.insert(Result.getLocation());
-          VariabilityStack.push_back({true, isMacroVariability(name), name});
-        }
-      }else if(II->getPPKeywordID() == tok::pp_ifndef){
-        createName
-        if (isMacroVariability(name)) {
-          VariabilityIfLocations.insert(Result.getLocation());
-          VariabilityStack.push_back({false, isMacroVariability(name), name});
-        }
-      }else if(II->getPPKeywordID() == tok::pp_if){
-        // not supported for variability aware analysis for now
-      }else if(II->getPPKeywordID() == tok::pp_elif){
-        // not supported for variability aware analysis for now
-      }
-    }
-    wasEndOfDirective = Result.is(tok::eod);
-  }
-
-#undef createName
-}
 
 void Preprocessor::AssignConditional(Token& Result){
   if (Result.getConditional() != nullptr) {

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -810,13 +810,11 @@ void Preprocessor::AssignConditional(Token& Result){
   std::vector<bool> decls;
   std::vector<std::string> names;
   for(auto vLoc = VariabilityStack.begin(); vLoc != VariabilityStack.end(); ++vLoc) {
-    if(vLoc->shouldUse){
-      //llvm::outs() << "Pushing decl:" << vLoc->isDef << "\n";;
-      decls.push_back(vLoc->isDef);
-      //llvm::outs() << "Pushing name:" << vLoc->name << "\n";;
-      names.push_back(vLoc->name);
-      //llvm::outs() << "Done Pushing\n";
-    }
+    //llvm::outs() << "Pushing decl:" << vLoc->isDef << "\n";;
+    decls.push_back(vLoc->isDef);
+    //llvm::outs() << "Pushing name:" << vLoc->name << "\n";;
+    names.push_back(vLoc->name);
+    //llvm::outs() << "Done Pushing\n";
   }
   if(decls.size() > 0){
     pc = Variability::PresenceCondition::getList(decls, names);

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -824,28 +824,20 @@ void Preprocessor::ManageMyStack(Token &Result){
         //<< "\n";
       if(II->getPPKeywordID() == tok::pp_ifdef){
         createName
-        //llvm::outs() << ")))Push: " << name << "\n";
-        VariabilityStack.push_back({true, isMacroVariability(name), name});
+        if (isMacroVariability(name)) {
+          VariabilityIfLocations.insert(Result.getLocation());
+          VariabilityStack.push_back({true, isMacroVariability(name), name});
+        }
       }else if(II->getPPKeywordID() == tok::pp_ifndef){
         createName
-        //llvm::outs() << ")))Push: ~" << name << "\n";
-        VariabilityStack.push_back({false, isMacroVariability(name), name});
-      }else if(II->getPPKeywordID() == tok::pp_else){
-        //llvm::outs() << ")))Flip\n";
-        VariabilityStack.back().isDef ^= true;
-      }else if(II->getPPKeywordID() == tok::pp_endif){
-        //llvm::outs() << ")))Pop\n";
-        VariabilityStack.pop_back();
+        if (isMacroVariability(name)) {
+          VariabilityIfLocations.insert(Result.getLocation());
+          VariabilityStack.push_back({false, isMacroVariability(name), name});
+        }
       }else if(II->getPPKeywordID() == tok::pp_if){
         // not supported for variability aware analysis for now
-        createName
-        VariabilityStack.push_back({true, false, name});
       }else if(II->getPPKeywordID() == tok::pp_elif){
         // not supported for variability aware analysis for now
-        createName
-        VariabilityStack.pop_back(); // if this was supported, this value would need to be stored
-        // and taken into account when deciding what to push back onto the stack
-        VariabilityStack.push_back({true, false, name});
       }
     }
     wasEndOfDirective = Result.is(tok::eod);


### PR DESCRIPTION
This pull request cleans up the mechanisms for managing `Preprocessor::VariabilityStack`.

# Summary of Changes

At a high level, the main change made was that entries are now only pushed to `Preprocessor::VariabilityStack` if the given macro will be used for variability-aware analysis. To accomplish this, the locations of `#ifdef`s (or eventually `#if`s) that were used for variability-aware analysis are stored on `VariabilityStack`. When an `#endif` is encountered, we compare the location of the corresponding `#ifdef` or `#if` to the location of the last entry pushed to `VariabilityStack`. If it matches, then we pop an item from `VariabilityStack`.

Lower level details:

* Reverted commit `cfbe60d05cdba3643fe92cfaf9495eaa29e475e5`. See revert commit `7a03bd6c0d03197db30c85a2ea6ceae56f1fe9d6`

* The `bool shouldUse` field was removed from the `VariabilityLocation` struct. Now, all the items in `VariabilityStack` should be used when calculating the presence condition of the current token, so this field is no longer needed.

* Added `SourceLocation IfLoc` field to the `VariabilityLocation` struct. This represents to location of the `#ifdef` (or eventually `#if`) directive that was used for variability-aware analysis.

* Created the method `bool Preprocessor::isVariabilityIfLoc` which returns true if the `SourceLocation` argument matches the `IfLoc` field of the `VariabilityLocation` at the top of `VariabilityStack`

* In `Preprocessor::HandleEndifDirective`, when an `#endif` is encountered, the location of the corresponding `#ifdef` (or `#if`) is checked using the method `isVariabilityIfLoc`. If that method returns true that means that the current `#endif` corresponds to the last `#ifdef` or `#if` that was pushed to `VariabilityStack`. In this case, an item is popped from `VariabilityStack`.

* In `Preprocessor::HandleElseDirective`, `isVariabilityIfLoc` is called to check if that `#else` corresponds to an `#ifdef` or `#if` used for variability-aware analysis. If so, this method will "flip" the `isDef` field of the top item in `VariabilityStack`. (I.e. change it from `true` to `false` or `false` to `true`).

* Since popping from `VariabilityStack` was now being done in various `Handle___Directive` methods, I thought it would be more consistent if pushing to the stack was also done in a similar method. Therefore, I moved the pushing functionality from the method `Preprocessor::ManageMyStack` to `Preprocessor::HandleIfdefDirective`. At this point, the method `ManageMyStack` was redundant so I removed it.

Note on `#elif` directives: The method `Preprocessor::HandleElifDirective` assumes it needs to skip the rest of the block. I think it doesn't really make sense to use `#elif` directives for variability-aware analysis until we have a way to parse the expression after `#elif` and create a presence condition from that. Therefore, as a temporary solution, the method `HandleElifDirective` just pops an entry from `VariabilityStack` if necessary and continues to skip the block.