### PR TITLE
Implement simple #if defined directives

### DIFF
--- a/include/clang/Basic/Conditional.h
+++ b/include/clang/Basic/Conditional.h
@@ -54,8 +54,8 @@ public:
     virtual PresenceCondition* toCnf();
     virtual PresenceCondition* toNegationNormal();
     // This function returns the presence condition based on the stack given
-    static PresenceCondition* getList(std::vector<bool> declarations,
-        std::vector<std::string> names);
+    static PresenceCondition *getList(std::vector<bool> isDefVector,
+                                      std::vector<PresenceCondition *> conditionVector);
 
     // These three methods are called to determine if th parser should split
     bool ShouldSplitOnCondition(PresenceCondition* other);

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -1980,6 +1980,13 @@ private:
   /// If the expression is equivalent to "!defined(X)" return X in IfNDefMacro.
   DirectiveEvalResult EvaluateDirectiveExpression(IdentifierInfo *&IfNDefMacro);
 
+  /// \brief Tries to parse the expression after an "#if" directive and
+  /// construct a PresenceCondition.
+  ///
+  /// Returns pointer to the PresenceCondition parsed. Will return nullptr
+  /// on failure.
+  Variability::PresenceCondition *TryParsePresenceCondition();
+
   /// \brief Install the standard preprocessor pragmas:
   /// \#pragma GCC poison/system_header/dependency and \#pragma once.
   void RegisterBuiltinPragmas();

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -122,7 +122,7 @@ enum MacroUse {
 struct VariabilityLocation{
     bool isDef;
     SourceLocation IfLoc;
-    std::string name;
+    Variability::PresenceCondition *condition;
 };
 
 /// \brief Engages in a tight little dance with the lexer to efficiently

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -354,7 +354,6 @@ public:
       return !hasVarConfigFile() || (VariabilityMacros.find(macroname) != VariabilityMacros.end());
   }
 
-private:
   /// \brief Returns true if IfLoc is the location of the last #if or #ifdef
   /// used for variability-aware analysis.
   bool isVariabilityIfLoc(SourceLocation IfLoc) {

--- a/lib/Basic/Conditional.cpp
+++ b/lib/Basic/Conditional.cpp
@@ -193,27 +193,25 @@ Or::Or(PresenceCondition* left_, PresenceCondition* right_) {
     this->typeOfPC = OR;
 }
 
-PresenceCondition* PresenceCondition::getList(std::vector<bool> declarations, std::vector<std::string> names) {
-    // unpacks the vectors from the condition stack to form the current conditional
-    if (names.size() == 0) {
-        return new True();
-    } else if (names.size() == 1) {
-        return declarations[0] ?
-            static_cast<PresenceCondition*>(new Literal(names[0])) :
-            static_cast<PresenceCondition*>(new Not(new Literal(names[0])));
-    } else {
-        PresenceCondition* pc = declarations[0] ?
-            static_cast<PresenceCondition*>(new Literal(names[0])) :
-            static_cast<PresenceCondition*>(new Not(new Literal(names[0])));
+PresenceCondition *
+PresenceCondition::getList(std::vector<bool> isDefVector,
+                           std::vector<PresenceCondition *> conditionVector) {
+  // unpacks the vectors from the condition stack to form the current
+  // conditional
+  if (conditionVector.size() == 0) {
+    return new True();
+  } else if (conditionVector.size() == 1) {
+    return isDefVector[0] ? conditionVector[0] : new Not(conditionVector[0]);
+  } else {
+    PresenceCondition *pc =
+        isDefVector[0] ? conditionVector[0] : new Not(conditionVector[0]);
 
-        for (unsigned long i = 1, e = names.size(); i < e; ++i) {
-            pc = new And(pc, declarations[i] ?
-                    static_cast<PresenceCondition*>(new Literal(names[i])) :
-                    static_cast<PresenceCondition*>(new Not(new Literal(names[i]))));
-        }
-        return pc;
+    for (unsigned long i = 1, e = conditionVector.size(); i < e; ++i) {
+      pc = new And(pc, isDefVector[i] ? conditionVector[i]
+                                      : new Not(conditionVector[i]));
     }
-
+    return pc;
+  }
 }
 PresenceCondition* PresenceCondition::toNegationNormal(){
     // this should never be called

--- a/lib/Lex/Lexer.cpp
+++ b/lib/Lex/Lexer.cpp
@@ -3876,11 +3876,9 @@ HandleDirective:
   IdentifierInfo *II = Result.getIdentifierInfo();
   if (!II) return false; // Not an identifier.
   if(II->getPPKeywordID() == tok::pp_ifdef ||
-     II->getPPKeywordID() == tok::pp_ifndef) {
-      Token t;
-      PP->getRawToken(Result.getEndLoc().getLocWithOffset(1), t, true);
-      std::string name = PP->getSpelling(t);
-      if(PP->isMacroVariability(name)){
+     II->getPPKeywordID() == tok::pp_ifndef ||
+     II->getPPKeywordID() == tok::pp_if) {
+      if (PP->isVariabilityIfLoc(Result.getLocation())) {
         // Return special split token
         Result.setKind(tok::split);
         // Set the presence condition of the split token to null.

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2775,8 +2775,12 @@ void Preprocessor::HandleIfDirective(Token &IfToken,
     ConditionalTrue = DER.Conditional;
   }
 
+  // Erase cached tokens from the conditional expression so they don't appear
+  // later when parsing statements
+  EraseCachedTokens(LastCachedTokenRange());
   // Exit caching mode so that CurPPLexer will not be null
   ExitCachingLexMode();
+
   const SourceLocation ConditionalEnd = CurPPLexer->getSourceLocation();
 
   // If this condition is equivalent to #ifndef X, and if this is the first

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2732,9 +2732,11 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
                                      /*foundelse*/false);
     std::string name = getSpelling(MacroNameTok);
     if (isIfndef)
-      VariabilityStack.push_back({false, DirectiveTok.getLocation(), name});
+      VariabilityStack.push_back(
+          {false, DirectiveTok.getLocation(), new Variability::Literal(name)});
     else
-      VariabilityStack.push_back({true, DirectiveTok.getLocation(), name});
+      VariabilityStack.push_back(
+          {true, DirectiveTok.getLocation(), new Variability::Literal(name)});
   } else if (!MI == isIfndef) {
     // Yes, remember that we are inside a conditional, then lex the next token.
     CurPPLexer->pushConditionalLevel(DirectiveTok.getLocation(),
@@ -2808,7 +2810,7 @@ void Preprocessor::HandleIfDirective(Token &IfToken,
     // Yes, perform variability-aware analysis on this block
     CurPPLexer->pushConditionalLevel(IfToken.getLocation(), /*wasskip*/false,
                                    /*foundnonskip*/true, /*foundelse*/false);
-    // TODO Push to VariabilityStack
+    VariabilityStack.push_back({true, IfToken.getLocation(), ParsedCondition});
   } else if (ConditionalTrue) {
     // Yes, remember that we are inside a conditional, then lex the next token.
     CurPPLexer->pushConditionalLevel(IfToken.getLocation(), /*wasskip*/false,

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -807,18 +807,15 @@ void Preprocessor::AssignConditional(Token& Result){
     return;
   }
   Variability::PresenceCondition* pc;
-  std::vector<bool> decls;
-  std::vector<std::string> names;
+  std::vector<bool> isDefVector;
+  std::vector<Variability::PresenceCondition *> conditionVector;
   for(auto vLoc = VariabilityStack.begin(); vLoc != VariabilityStack.end(); ++vLoc) {
-    //llvm::outs() << "Pushing decl:" << vLoc->isDef << "\n";;
-    decls.push_back(vLoc->isDef);
-    //llvm::outs() << "Pushing name:" << vLoc->name << "\n";;
-    names.push_back(vLoc->name);
-    //llvm::outs() << "Done Pushing\n";
+    isDefVector.push_back(vLoc->isDef);
+    conditionVector.push_back(vLoc->condition);
   }
-  if(decls.size() > 0){
-    pc = Variability::PresenceCondition::getList(decls, names);
-  }else{
+  if (isDefVector.size() > 0) {
+    pc = Variability::PresenceCondition::getList(isDefVector, conditionVector);
+  } else {
     pc = new Variability::True();
   }
   Result.setConditionalInfo(pc);


### PR DESCRIPTION
This pull request implements analysis for simple `#if defined` directives. So far only the following syntaxes are supported:

`#if defined X`
`#if defined(X)`
`#if !defined X`
`#if !defined(X)`

Main changes:

* Created method `Preprocessor::TryParsePresenceCondition` to attempts to parse a boolean expression that occurs after an `#if` directive.
* `Preprocessor::HandleIfDirective` was modified to call `TryParsePresenceCondition`.
  * If `TryParsePresenceCondition` fails, the preprocessor backtracks and evaluates the conditional expresssion as clang normally would.
  * A new `CachedTokens` vector is created at the beginning of `HandleIfDirective` so that caching of tokens here doesn't interfere with caching elsewhere.
* `Preprocessor::VariabilityStack` now stores a `PresenceCondition` pointers instead of just strings containing macro names. This is so that we can eventually support more complicated conditions such as `#if defined(A) && defined(B)`.