### PR TITLE
Fix macro expansion

### DIFF
--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -1262,6 +1262,11 @@ public:
   /// \brief Lex the next token for this preprocessor.
   void Lex(Token &Result);
 
+  /// \brief Computes the current presence condition based on the state of
+  /// VariabilityStack
+  Variability::PresenceCondition *ComputeConditional();
+
+  /// \brief Assigns a presence condition to a Token
   void AssignConditional(Token &Result);
 
   void LexAfterModuleImport(Token &Result);

--- a/lib/Lex/PPMacroExpansion.cpp
+++ b/lib/Lex/PPMacroExpansion.cpp
@@ -584,6 +584,13 @@ bool Preprocessor::HandleMacroExpandedIdentifier(Token &Identifier,
     // Replace the result token.
     Identifier = MI->getReplacementToken(0);
 
+    // Assign a new presence condition to the replacement token to ensure its
+    // condition matches the expansion location and the the definition location.
+    // Eventually, we should also take into account the presence condition of
+    // the definition.
+    Variability::PresenceCondition *pc = ComputeConditional();
+    Identifier.setConditionalInfo(pc);
+
     // Restore the StartOfLine/LeadingSpace markers.
     Identifier.setFlagValue(Token::StartOfLine , isAtStartOfLine);
     Identifier.setFlagValue(Token::LeadingSpace, hasLeadingSpace);

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -817,22 +817,25 @@ void Preprocessor::Lex(Token &Result) {
   //llvm::outs() << Result.getConditional()->toString() << "\n";
 }
 
-void Preprocessor::AssignConditional(Token& Result){
-  if (Result.getConditional() != nullptr) {
-    return;
-  }
-  Variability::PresenceCondition* pc;
+Variability::PresenceCondition *Preprocessor::ComputeConditional() {
   std::vector<bool> isDefVector;
   std::vector<Variability::PresenceCondition *> conditionVector;
   for(auto vLoc = VariabilityStack.begin(); vLoc != VariabilityStack.end(); ++vLoc) {
     isDefVector.push_back(vLoc->isDef);
     conditionVector.push_back(vLoc->condition);
   }
-  if (isDefVector.size() > 0) {
-    pc = Variability::PresenceCondition::getList(isDefVector, conditionVector);
-  } else {
-    pc = new Variability::True();
-  }
+
+  if (isDefVector.size() > 0)
+    return Variability::PresenceCondition::getList(isDefVector, conditionVector);
+
+  return new Variability::True();
+}
+
+void Preprocessor::AssignConditional(Token &Result) {
+  if (Result.getConditional() != nullptr)
+    return;
+
+  Variability::PresenceCondition* pc = ComputeConditional();
   Result.setConditionalInfo(pc);
 }
 


### PR DESCRIPTION
Fixes issue where expanded macro tokens retained the presence condition from their definition location instead of being assigned the presence condition of their expansion location.

Fixes #48 