### PR TITLE
Conditional macros

### DIFF
--- a/include/clang/Lex/MacroInfo.h
+++ b/include/clang/Lex/MacroInfo.h
@@ -16,6 +16,7 @@
 #define LLVM_CLANG_LEX_MACROINFO_H
 
 #include "clang/Lex/Token.h"
+#include "clang/Basic/Conditional.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -317,6 +318,9 @@ protected:
   MacroDirective(Kind K, SourceLocation Loc)
       : Loc(Loc), MDKind(K), IsFromPCH(false), IsPublic(true) {}
 
+  /// \brief The presence condition under which this macro directive was seen.
+  Variability::PresenceCondition *condition;
+
 public:
   Kind getKind() const { return Kind(MDKind); }
 
@@ -400,6 +404,12 @@ public:
   void dump() const;
 
   static bool classof(const MacroDirective *) { return true; }
+
+  Variability::PresenceCondition *getConditional() { return condition; }
+
+  void setConditional(Variability::PresenceCondition *condition) {
+    this->condition = condition;
+  }
 };
 
 /// \brief A directive for a defined macro or a macro imported from a module.

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -1266,6 +1266,14 @@ public:
   /// VariabilityStack
   Variability::PresenceCondition *ComputeConditional();
 
+  /// \brief Creates a presence condition to represent the given macro name in
+  /// terms of only macros which are considered points of variability. Also
+  /// takes into account previous #define's and #undef's for the macro.
+  /// \param MacroNameTok The token that holds the name of the macro.
+  /// \returns The normalized presence condition.
+  Variability::PresenceCondition *
+  NormalizedPresenceConditionFromMacroName(const Token &MacroNameTok);
+
   /// \brief Assigns a presence condition to a Token
   void AssignConditional(Token &Result);
 

--- a/include/clang/Lex/Preprocessor.h
+++ b/include/clang/Lex/Preprocessor.h
@@ -1269,10 +1269,10 @@ public:
   /// \brief Creates a presence condition to represent the given macro name in
   /// terms of only macros which are considered points of variability. Also
   /// takes into account previous #define's and #undef's for the macro.
-  /// \param MacroNameTok The token that holds the name of the macro.
+  /// \param MacroII Pointer to IdentifierInfo that holds the name of the macro.
   /// \returns The normalized presence condition.
   Variability::PresenceCondition *
-  NormalizedPresenceConditionFromMacroName(const Token &MacroNameTok);
+  NormalizedPresenceConditionFromMacroName(const IdentifierInfo *MacroII);
 
   /// \brief Assigns a presence condition to a Token
   void AssignConditional(Token &Result);

--- a/include/clang/Lex/PreprocessorLexer.h
+++ b/include/clang/Lex/PreprocessorLexer.h
@@ -123,6 +123,13 @@ protected:
 
   unsigned getConditionalStackDepth() const { return ConditionalStack.size(); }
 
+  // A flag which can be used to toggle whether or not the lexer inserts a split
+  // token at the next #if or #ifdef
+  bool shouldInsertSplit = true;
+  bool shouldSplit() { return shouldInsertSplit; }
+  void setNoSplit() { shouldInsertSplit = false; }
+  void setSplit() { shouldInsertSplit = true; }
+
 public:
   PreprocessorLexer(const PreprocessorLexer &) = delete;
   PreprocessorLexer &operator=(const PreprocessorLexer &) = delete;

--- a/lib/Lex/Lexer.cpp
+++ b/lib/Lex/Lexer.cpp
@@ -3873,6 +3873,13 @@ HandleDirective:
     return true;
   }
 
+  // The preprocessor may have disabled the inserting of the split token by
+  // calling setNoSplit(). If so, return early here.
+  if (!shouldSplit()) {
+    setSplit();
+    return false;
+  }
+
   IdentifierInfo *II = Result.getIdentifierInfo();
   if (!II) return false; // Not an identifier.
   if(II->getPPKeywordID() == tok::pp_ifdef ||

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2755,6 +2755,11 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
   Variability::And conjunction(pc, ComputeConditional());
   bool satisfiable = conjunction.isSatisfiable();
 
+  // If #ifdef condition is equivalent to current preprocessor condition, we
+  // shouldn't insert a split token or the parser will get confused
+  if (ComputeConditional()->EquivalentTo(pc))
+    CurPPLexer->setNoSplit();
+
   // Should we include the stuff contained by this directive?
   if (PPOpts->SingleFileParseMode && !MI) {
     // In 'single-file-parse mode' undefined identifiers trigger parsing of all
@@ -2850,6 +2855,11 @@ void Preprocessor::HandleIfDirective(Token &IfToken,
     // preprocessor condition is satisfiable
     Variability::And conjunction(ParsedCondition, ComputeConditional());
     bool satisfiable = conjunction.isSatisfiable();
+
+    // If #if condition is equivalent to current preprocessor condition, we
+    // shouldn't insert a split token or the parser will get confused
+    if (ComputeConditional()->EquivalentTo(ParsedCondition))
+      CurPPLexer->setNoSplit();
 
     if (satisfiable) {
       // Yes, perform variability-aware analysis on this block

--- a/lib/Lex/PPDirectives.cpp
+++ b/lib/Lex/PPDirectives.cpp
@@ -2757,7 +2757,7 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
 
   // If #ifdef condition is equivalent to current preprocessor condition, we
   // shouldn't insert a split token or the parser will get confused
-  if (ComputeConditional()->EquivalentTo(pc))
+  if (ComputeConditional()->EquivalentTo(&conjunction))
     CurPPLexer->setNoSplit();
 
   // Should we include the stuff contained by this directive?
@@ -2858,7 +2858,7 @@ void Preprocessor::HandleIfDirective(Token &IfToken,
 
     // If #if condition is equivalent to current preprocessor condition, we
     // shouldn't insert a split token or the parser will get confused
-    if (ComputeConditional()->EquivalentTo(ParsedCondition))
+    if (ComputeConditional()->EquivalentTo(&conjunction))
       CurPPLexer->setNoSplit();
 
     if (satisfiable) {

--- a/lib/Lex/PPExpressions.cpp
+++ b/lib/Lex/PPExpressions.cpp
@@ -908,14 +908,14 @@ Variability::PresenceCondition *Preprocessor::TryParsePresenceCondition() {
     return nullptr;
   }
 
-  if (DT.State == DefinedTracker::DefinedMacro &&
-      isMacroVariability(DT.TheMacro->getName())) {
+  if (DT.State == DefinedTracker::DefinedMacro) {
     // Parsed "defined(X)"
-    return new Variability::Literal(DT.TheMacro->getName());
-  } else if (DT.State == DefinedTracker::NotDefinedMacro &&
-             isMacroVariability(DT.TheMacro->getName())) {
+    return NormalizedPresenceConditionFromMacroName(DT.TheMacro);
+  } else if (DT.State == DefinedTracker::NotDefinedMacro) {
     // Parsed "!defined(X)"
-    return new Variability::Not(new Variability::Literal(DT.TheMacro->getName()));
+    Variability::PresenceCondition *pc =
+        NormalizedPresenceConditionFromMacroName(DT.TheMacro);
+    return new Variability::Not(pc);
   } else {
     // Parsed something other than a "defined(X)" or "!defined(X)" so return failure
     return nullptr;

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -832,15 +832,13 @@ Variability::PresenceCondition *Preprocessor::ComputeConditional() {
 }
 
 Variability::PresenceCondition *
-Preprocessor::NormalizedPresenceConditionFromMacroName(const Token &MacroNameTok) {
+Preprocessor::NormalizedPresenceConditionFromMacroName(const IdentifierInfo *MacroII) {
   Variability::PresenceCondition *pc = nullptr;
 
   // The given macro will be defined under any of the presence conditions of its
   // previous definitions.
   // TODO any previous #undef's need to be handled differently here.
-  for (MacroDirective *i =
-           CurSubmoduleState->Macros[MacroNameTok.getIdentifierInfo()]
-               .getLatest();
+  for (MacroDirective *i = CurSubmoduleState->Macros[MacroII].getLatest();
        i != nullptr; i = i->getPrevious()) {
     if (!pc)
       pc = i->getConditional();
@@ -848,7 +846,7 @@ Preprocessor::NormalizedPresenceConditionFromMacroName(const Token &MacroNameTok
       pc = new Variability::Or(pc, i->getConditional());
   }
 
-  std::string name = getSpelling(MacroNameTok);
+  std::string name = MacroII->getName();
   if (isMacroVariability(name)) {
     // If the macro is a point of variability, then include it in the presence
     // condition

--- a/lib/Lex/Preprocessor.cpp
+++ b/lib/Lex/Preprocessor.cpp
@@ -840,6 +840,10 @@ Preprocessor::NormalizedPresenceConditionFromMacroName(const IdentifierInfo *Mac
   // TODO any previous #undef's need to be handled differently here.
   for (MacroDirective *i = CurSubmoduleState->Macros[MacroII].getLatest();
        i != nullptr; i = i->getPrevious()) {
+    // Don't include unsatisfiable directives in the disjunction.
+    if (!i->getConditional() || !i->getConditional()->isSatisfiable())
+      continue;
+
     if (!pc)
       pc = i->getConditional();
     else


### PR DESCRIPTION
This pull request implements "conditional macros" as described in this paper: https://www.cs.cmu.edu/~ckaestne/pdf/vamos11.pdf

A a high level, the main changes are:
- Assign a presence condition to every macro definition (i.e. every `#define` directive)
- Every time an `#if` or `#ifdef` is encountered, we attempt to "normalize" its conditional expression (i.e. re-write it in terms of macros that are user-defined). See the paper for further explanation of this "normalization".